### PR TITLE
Fix ant-javacard usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,7 @@ before_script:
    - cd jckit
    - "[ -f java_card_kit-2_2_1-linux-dom.zip ] || curl -L http://download.oracle.com/otn-pub/java/java_card_kit/2.2.1/java_card_kit-2_2_1-linux-dom.zip -o java_card_kit-2_2_1-linux-dom.zip --cookie oraclelicense=accept-securebackup-cookie"
    - unzip java_card_kit-2_2_1-linux-dom.zip
-   - cd java_card_kit-2_2_1/
-   - cd ../..
-   - mkdir ext
-   - cd ext
-   - mkdir ant
-   - cd ant
-   - "[ -f ant-javacard.jar ] || curl -L https://github.com/martinpaljak/ant-javacard/releases/download/v1.3/ant-javacard.jar -o ant-javacard.jar"
-   - cd ../..
-   - CLASSPATH=$CLASSPATH:$JC_HOME/lib
+   - cd ..
 
 script: ant dist
 

--- a/build.xml
+++ b/build.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Gids Applet" default="dist" basedir=".">
   <description>Builds the project. </description>
+  <get src="https://github.com/martinpaljak/ant-javacard/releases/download/18.06.25/ant-javacard.jar" dest="." skipexisting="true"/>
+  <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
   <target name="dist" description="generate the distribution">
     <tstamp/>
    
     <!-- Create the distribution directory -->
-    <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ext/ant/ant-javacard.jar"/>
     <javacard>
      <cap aid="A0:00:00:03:97:42:54:46:59" output="GidsApplet.cap" sources="src/com/mysmartlogon/gidsApplet" version="1.0">
         <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>


### PR DESCRIPTION
Ant can download the jar on demand. Add it to build.xml and remove from Travis. This way `ant` requires only a valid `$JC_HOME` to function.