### PR TITLE
J3H145 and 4K RSA  support

### DIFF
--- a/src/com/mysmartlogon/gidsApplet/GidsApplet.java
+++ b/src/com/mysmartlogon/gidsApplet/GidsApplet.java
@@ -74,6 +74,9 @@ public class GidsApplet extends Applet {
     public static final byte INS_ACTIVATE_FILE = (byte) 0x44;
     public static final byte INS_TERMINATE_DF = (byte) 0xE6;
 
+    public static final short LENGTH_RSA_3072 = (short) 3072;
+    public static final short LENGTH_RSA_4096 = (short) 4096;
+
     private GidsPINManager pinManager = null;
 
 
@@ -421,6 +424,12 @@ public class GidsApplet extends Applet {
                 break;
             case (byte)0x07:
                 kp = new KeyPair(KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_2048);
+                break;
+            case (byte)0x08:
+                kp = new KeyPair(KeyPair.ALG_RSA_CRT, LENGTH_RSA_3072);
+                break;
+            case (byte)0x09:
+                kp = new KeyPair(KeyPair.ALG_RSA_CRT, LENGTH_RSA_4096);
                 break;
             default:
                 ISOException.throwIt(ISO7816.SW_FUNC_NOT_SUPPORTED);

--- a/src/com/mysmartlogon/gidsApplet/GidsApplet.java
+++ b/src/com/mysmartlogon/gidsApplet/GidsApplet.java
@@ -766,13 +766,8 @@ public class GidsApplet extends Applet {
 
             rsaRawCipher.init(rsaKey, Cipher.MODE_ENCRYPT);
             sigLen = rsaRawCipher.doFinal(ram_buf, (short) 0, lc, ram_buf, (short)0);
-            // A single short APDU can handle 256 bytes - only one send operation neccessary.
-            le = apdu.setOutgoing();
-            if(le > 0 && le < sigLen) {
-                ISOException.throwIt(ISO7816.SW_CORRECT_LENGTH_00);
-            }
-            apdu.setOutgoingLength(sigLen);
-            apdu.sendBytesLong(ram_buf, (short) 0, sigLen);
+
+            transmitManager.sendDataFromRamBuffer(apdu, (short)0, sigLen);
             break;
         case (byte) 0x50:
             // rsa padding made by the card, only the hash is provided
@@ -795,13 +790,7 @@ public class GidsApplet extends Applet {
                 ISOException.throwIt(ISO7816.SW_UNKNOWN);
             }*/
 
-            // A single short APDU can handle 256 bytes - only one send operation neccessary.
-            le = apdu.setOutgoing();
-            if(le > 0 && le < sigLen) {
-                ISOException.throwIt(ISO7816.SW_CORRECT_LENGTH_00);
-            }
-            apdu.setOutgoingLength(sigLen);
-            apdu.sendBytesLong(ram_buf, (short) 0, sigLen);
+            transmitManager.sendDataFromRamBuffer(apdu, (short)0, sigLen);
             break;
 
         default:

--- a/src/com/mysmartlogon/gidsApplet/GidsApplet.java
+++ b/src/com/mysmartlogon/gidsApplet/GidsApplet.java
@@ -438,11 +438,13 @@ public class GidsApplet extends Applet {
             kp.genKeyPair();
             
             // special Feitian workaround for A40CR and A22CR cards
-            RSAPrivateCrtKey priKey = (RSAPrivateCrtKey) kp.getPrivate();
-            short pLen = priKey.getP(buf, (short) 0);
-            priKey.setP(buf, (short) 0, pLen);
-            short qLen = priKey.getQ(buf, (short) 0);
-            priKey.setQ(buf, (short) 0, qLen);
+            // but it breaks J3H145 :(
+            //
+            // RSAPrivateCrtKey priKey = (RSAPrivateCrtKey) kp.getPrivate();
+            // short pLen = priKey.getP(buf, (short) 0);
+            // priKey.setP(buf, (short) 0, pLen);
+            // short qLen = priKey.getQ(buf, (short) 0);
+            // priKey.setQ(buf, (short) 0, qLen);
             // end of workaround
             
         } catch(CryptoException e) {


### PR DESCRIPTION
This gets (with a small patch to opensc) 4K RSA support working on 4K enabled J3H145 cards. 

I'm not suggesting this be merged /as is/, as there are some things to address, but wanted to start the discussion.

1) The feitian workaround https://github.com/vletoux/GidsApplet/commit/24e2e880b59c5f3dbc7a412a6cf5949018b22c75 , breaks all RSA on these cards.

2) This doesn't address discovery of RSA 3072 and RSA 4096 in the FCP template. The standards
are fairly opaque as to what tags need adding. I'm guessing all that's needed is the Cryptographic Mechanism Reference in the 0x80 tag and the bizzare OID in the 0x6 tag that follows is ignored, but I've not tried.
