### PR TITLE
Add a build variant with increased flash buffer size, enough to handle 4096-bit RSA imports.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,28 +28,41 @@
   <description>Builds the project. </description>
   <get src="https://github.com/martinpaljak/ant-javacard/releases/download/v23.08.29/ant-javacard.jar" dest="." skipexisting="true"/>
   <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
+
+  <!-- properties shared by all variants -->
+  <property name="cap.ver"    value="1.0" />
+  <property name="cap.aid"    value="A0:00:00:03:97:42:54:46:59" /> <!-- Microsoft IDMP AID aka MsGidsAID-->
+  <property name="applet.aid" value="${cap.aid}:02:01" /><!-- extra bytes: GIDS 2.0, app reserved -->
+  <property name="mainclass"  value="com.mysmartlogon.gidsApplet.GidsApplet"/>
+
+  <!-- sources used by all variants -->
+  <property name="src.common" value="src/com/mysmartlogon/gidsApplet" />
+  <!-- per-variant source dirs -->
+  <property name="src.2k"     value="src/import2048/com/mysmartlogon/gidsApplet" />
+  <property name="src.4k"     value="src/import4096/com/mysmartlogon/gidsApplet" />
+
   <target name="dist" description="generate the distribution">
     <tstamp/>
 
     <!-- Standard version - buffer size limits 4096-bit RSA key support to be on-card generated only -->
     <javacard>
       <cap
-          aid="A0:00:00:03:97:42:54:46:59"
+          aid="${cap.aid}"
           output="GidsApplet.cap"
-          sources="src/com/mysmartlogon/gidsApplet;src/import2048/com/mysmartlogon/gidsApplet"
-          version="1.0">
-        <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>
+          sources="${src.common};${src.2k}"
+          version="${cap.ver}">
+        <applet class="${mainclass}" aid="${applet.aid}"/>
       </cap>
     </javacard>
 
     <!-- Extended version - Will attempt to import 4096-bit RSA keys if your card can do it -->
     <javacard>
       <cap
-          aid="A0:00:00:03:97:42:54:46:59"
+          aid="${cap.aid}"
           output="GidsApplet-import4k.cap"
-          sources="src/com/mysmartlogon/gidsApplet;src/import4096/com/mysmartlogon/gidsApplet"
-          version="1.0">
-        <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>
+          sources="${src.common};${src.4k}"
+          version="${cap.ver}">
+        <applet class="${mainclass}" aid="${applet.aid}"/>
       </cap>
     </javacard>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -31,9 +31,12 @@
   <target name="dist" description="generate the distribution">
     <tstamp/>
 
-    <!-- Create the distribution directory -->
     <javacard>
-     <cap aid="A0:00:00:03:97:42:54:46:59" output="GidsApplet.cap" sources="src/com/mysmartlogon/gidsApplet" version="1.0">
+      <cap
+          aid="A0:00:00:03:97:42:54:46:59"
+          output="GidsApplet.cap"
+          sources="src/com/mysmartlogon/gidsApplet;src/import2048/com/mysmartlogon/gidsApplet"
+          version="1.0">
         <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>
       </cap>
     </javacard>

--- a/build.xml
+++ b/build.xml
@@ -31,6 +31,7 @@
   <target name="dist" description="generate the distribution">
     <tstamp/>
 
+    <!-- Standard version - buffer size limits 4096-bit RSA key support to be on-card generated only -->
     <javacard>
       <cap
           aid="A0:00:00:03:97:42:54:46:59"
@@ -40,9 +41,21 @@
         <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>
       </cap>
     </javacard>
+
+    <!-- Extended version - Will attempt to import 4096-bit RSA keys if your card can do it -->
+    <javacard>
+      <cap
+          aid="A0:00:00:03:97:42:54:46:59"
+          output="GidsApplet-import4k.cap"
+          sources="src/com/mysmartlogon/gidsApplet;src/import4096/com/mysmartlogon/gidsApplet"
+          version="1.0">
+        <applet class="com.mysmartlogon.gidsApplet.GidsApplet" aid="A0:00:00:03:97:42:54:46:59:02:01"/>
+      </cap>
+    </javacard>
   </target>
   <target name="clean" description="clean up">
     <!-- Delete the built applet -->
     <delete dir="GidsApplet.cap"/>
+    <delete dir="GidsApplet-import4k.cap"/>
   </target>
 </project>

--- a/src/com/mysmartlogon/gidsApplet/TransmitManager.java
+++ b/src/com/mysmartlogon/gidsApplet/TransmitManager.java
@@ -38,7 +38,6 @@ public class TransmitManager {
     // a ram buffer for public key export (no need to allocate flash !)
     // memory buffer size is determined by copyRecordsToRamBuf=min 512
     private static final short RAM_BUF_SIZE = (short) 530;
-    private static final short FLASH_BUF_SIZE = (short) 1220;
     private byte[] ram_buf = null;
     // internal variables to do chaining
     private short[] chaining_cache = null;
@@ -102,7 +101,7 @@ public class TransmitManager {
                 flash_buf = null;
                 JCSystem.requestObjectDeletion();
             } else {
-                Util.arrayFillNonAtomic(flash_buf, (short)0, FLASH_BUF_SIZE, (byte)0x00);
+                Util.arrayFillNonAtomic(flash_buf, (short)0, Config.FLASH_BUF_SIZE, (byte)0x00);
             }
         }
     }
@@ -193,7 +192,7 @@ public class TransmitManager {
         if (flash_buf == null)
         {
             try {
-                flash_buf = new byte[FLASH_BUF_SIZE];
+                flash_buf = new byte[Config.FLASH_BUF_SIZE];
             } catch(SystemException e) {
                 if(e.getReason() == SystemException.NO_RESOURCE) {
                     ISOException.throwIt(ISO7816.SW_FILE_FULL);
@@ -201,7 +200,7 @@ public class TransmitManager {
                 ISOException.throwIt(ISO7816.SW_UNKNOWN);
             }
         }
-        return doChainingOrExtAPDUWithBuffer(apdu, flash_buf, FLASH_BUF_SIZE);
+        return doChainingOrExtAPDUWithBuffer(apdu, flash_buf, Config.FLASH_BUF_SIZE);
     }
 
     private short doChainingOrExtAPDUWithBuffer(APDU apdu, byte[] databuffer, short bufferlen) throws ISOException {

--- a/src/import2048/com/mysmartlogon/gidsApplet/Config.java
+++ b/src/import2048/com/mysmartlogon/gidsApplet/Config.java
@@ -1,0 +1,33 @@
+/*
+ * GidsApplet: A Java Card implementation of the GIDS (Generic Identity
+ * Device Specification) specification
+ * https://msdn.microsoft.com/en-us/library/windows/hardware/dn642100%28v=vs.85%29.aspx
+ * Copyright (C) 2016  Vincent Le Toux(vincent.letoux@mysmartlogon.com)
+ *
+ * It has been based on the IsoApplet
+ * Copyright (C) 2014  Philip Wendland (wendlandphilip@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.mysmartlogon.gidsApplet;
+
+public class Config {
+    // This is the primary limitation on the size of imported keys.
+    // 1220 is enough for RSA/2048. (This means 4096-bit keys must be generated on-card.)
+    public static final short FLASH_BUF_SIZE = (short) 1220;
+}

--- a/src/import4096/com/mysmartlogon/gidsApplet/Config.java
+++ b/src/import4096/com/mysmartlogon/gidsApplet/Config.java
@@ -1,0 +1,33 @@
+/*
+ * GidsApplet: A Java Card implementation of the GIDS (Generic Identity
+ * Device Specification) specification
+ * https://msdn.microsoft.com/en-us/library/windows/hardware/dn642100%28v=vs.85%29.aspx
+ * Copyright (C) 2016  Vincent Le Toux(vincent.letoux@mysmartlogon.com)
+ *
+ * It has been based on the IsoApplet
+ * Copyright (C) 2014  Philip Wendland (wendlandphilip@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.mysmartlogon.gidsApplet;
+
+public class Config {
+    // This is the primary limitation on the size of imported keys.
+    // 2372 is enough for RSA/4096 but might be larger than needed. (2364 was not enough)
+    public static final short FLASH_BUF_SIZE = (short) 2372;
+}


### PR DESCRIPTION
~~This is rather crude, and not quite minimal. It also appears that it will require this much space at some point no matter key import size (when built with this patch), not just for 4096-bit imported keys.~~

~~But I am not familiar enough with the platform to do this better. I think probably ideally there would be two cap files generated, one with the larger import buffer and one with the original.~~

This now has two variants built by ant: the original, and one with the enlarged buffer.

I briefly tested this on a JavaCard 2.2.1 without 4096 RSA support and it seemed to still work fine (4096 rsa import errors with a different error), though I did not try importing an RSA key. I also don't have a simulator set up to run the tests.