### PR TITLE
Fix compatibility with EMV cards (fixes #10)

### DIFF
--- a/src/main/com/mysmartlogon/gidsApplet/CRTKeyFile.java
+++ b/src/main/com/mysmartlogon/gidsApplet/CRTKeyFile.java
@@ -32,7 +32,6 @@ import javacard.framework.JCSystem;
 import javacard.framework.Util;
 import javacard.security.CryptoException;
 import javacard.security.KeyBuilder;
-import javacard.security.KeyPair;
 import javacard.security.RSAPrivateCrtKey;
 import javacard.security.RSAPublicKey;
 
@@ -44,7 +43,8 @@ public class CRTKeyFile extends ElementaryFile {
     private final short posCRT;
     private final short lenCRT;
 
-    private KeyPair keyPair = null;
+    private RSAPublicKey rsaPublicKey = null;
+    private RSAPrivateCrtKey rsaPrivateKey = null;
     private byte[] symmetricKey = null;
 
     public CRTKeyFile(short fileID, byte[] fileControlInformation, short pos, short len) {
@@ -63,22 +63,31 @@ public class CRTKeyFile extends ElementaryFile {
         if (symmetricKey != null) {
             symmetricKey = null;
         }
-        if (keyPair != null) {
-            keyPair.getPrivate().clearKey();
-            keyPair = null;
+        if (rsaPublicKey != null) {
+            rsaPublicKey.clearKey();
+            rsaPublicKey = null;
+        }
+        if (rsaPrivateKey != null) {
+            rsaPrivateKey.clearKey();
+            rsaPrivateKey = null;
         }
         if(JCSystem.isObjectDeletionSupported()) {
             JCSystem.requestObjectDeletion();
         }
     }
 
-    public void SaveKey(KeyPair kp) {
+    public void SaveKey(RSAPublicKey publicKey, RSAPrivateCrtKey privateKey) {
         clearContents();
-        keyPair = kp;
+        rsaPublicKey = publicKey;
+        rsaPrivateKey = privateKey;
     }
 
-    public KeyPair GetKey() {
-        return keyPair;
+    public RSAPublicKey GetPublicKey() {
+        return rsaPublicKey;
+    }
+
+    public RSAPrivateCrtKey GetPrivateKey() {
+        return rsaPrivateKey;
     }
 
     public void CheckUsage(byte operation, byte algRef) throws NotFoundException {
@@ -342,7 +351,8 @@ public class CRTKeyFile extends ElementaryFile {
             // If the key is usable, it MUST NOT remain in buf.
             Util.arrayFillNonAtomic(buffer, offset, length, (byte)0x00);
             clearContents();
-            this.keyPair = new KeyPair(rsaPuKey, rsaPrKey);
+            this.rsaPublicKey = rsaPuKey;
+            this.rsaPrivateKey = rsaPrKey;
             if(JCSystem.isObjectDeletionSupported()) {
                 JCSystem.requestObjectDeletion();
             }

--- a/src/main/com/mysmartlogon/gidsApplet/GidsApplet.java
+++ b/src/main/com/mysmartlogon/gidsApplet/GidsApplet.java
@@ -283,7 +283,7 @@ public class GidsApplet extends Applet {
                     ISOException.throwIt(ISO7816.SW_DATA_INVALID);
                 }
                 file.CheckPermission(pinManager, File.ACL_OP_KEY_GETPUBLICKEY);
-                PublicKey pk = file.GetKey().getPublic();
+                PublicKey pk = file.GetPublicKey();
 
                 // Return pubkey. See ISO7816-8 table 3.
                 try {
@@ -463,7 +463,7 @@ public class GidsApplet extends Applet {
             }
             ISOException.throwIt(ISO7816.SW_UNKNOWN);
         }
-        file.SaveKey(kp);
+        file.SaveKey((RSAPublicKey) kp.getPublic(), (RSAPrivateCrtKey) kp.getPrivate());
 
         // Return pubkey. See ISO7816-8 table 3.
         try {
@@ -718,7 +718,7 @@ public class GidsApplet extends Applet {
         // Get the key - it must be an RSA private key,
         // checks have been done in MANAGE SECURITY ENVIRONMENT.
         CRTKeyFile key = (CRTKeyFile) currentKey[0];
-        PrivateKey theKey = key.GetKey().getPrivate();
+        PrivateKey theKey = key.GetPrivateKey();
 
         // Check the length of the cipher.
         // Note: The first byte of the data field is the padding indicator
@@ -767,7 +767,7 @@ public class GidsApplet extends Applet {
             lc = transmitManager.doChainingOrExtAPDU(apdu);
 
             // RSA signature operation.
-            rsaKey = key.GetKey().getPrivate();
+            rsaKey = key.GetPrivateKey();
 
             rsaRawCipher.init(rsaKey, Cipher.MODE_ENCRYPT);
             sigLen = rsaRawCipher.doFinal(ram_buf, (short) 0, lc, ram_buf, (short)0);
@@ -782,7 +782,7 @@ public class GidsApplet extends Applet {
             lc = apdu.setIncomingAndReceive();
 
             // RSA signature operation.
-            rsaKey = key.GetKey().getPrivate();
+            rsaKey = key.GetPrivateKey();
 
             if(lc > (short) 247) {
                 ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);


### PR DESCRIPTION
The card raises an exception when referencing `KeyPair`. This commit fixes it by simply using separate private and public key objects, and using `KeyPair` only for key generation (which these cards do not support)